### PR TITLE
feat: Improve error message for failed JSON decoding

### DIFF
--- a/post_tweet.php
+++ b/post_tweet.php
@@ -112,7 +112,12 @@ if ($http_status === 201 && isset($response_data['data']['id'])) {
             }
         }
     } else {
-        $error_message .= "Response: $response\n";
+        $error_message .=
+            "Response: " .
+            ($response === null
+                ? "Could not decode JSON response."
+                : $response) .
+            "\n";
     }
 
     echo $error_message;


### PR DESCRIPTION
Enhances the error message displayed when the Twitter API response cannot be decoded as JSON. Instead of showing an empty "Response:", it now explicitly states "Could not decode JSON response." if the `$response` variable is `null`, providing clearer feedback in such cases.